### PR TITLE
ci: add runalltests.sh and project test scripts

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Jenkins will set WORKSPACE to the top level directory that contains
+# the stratis-cli git repo
+if [ -z "$WORKSPACE" ]
+then
+    echo "Required WORKSPACE environment variable not set"
+    exit 1
+fi
+
+export STRATIS_DEPS_DIR=$WORKSPACE/stratis-deps
+
+cd $WORKSPACE
+
+# If there is a stale STRATIS_DEPS_DIR remove it
+if [ -d $STRATIS_DEPS_DIR ]
+then
+    rm -rf $STRATIS_DEPS_DIR
+fi
+
+
+mkdir $STRATIS_DEPS_DIR
+cd $STRATIS_DEPS_DIR
+
+# Clone the dependencies
+git clone https://github.com/stratis-storage/dbus-python-client-gen.git
+git clone https://github.com/stratis-storage/dbus-client-gen.git
+git clone https://github.com/stratis-storage/into-dbus-python.git
+git clone https://github.com/stratis-storage/dbus-signature-pyparsing.git
+git clone https://github.com/stratis-storage/stratisd.git
+
+if [ ! -f  /etc/dbus-1/system.d/stratisd.conf ]
+then
+    cp $STRATIS_DEPS_DIR/stratisd/stratisd.conf /etc/dbus-1/system.d/.
+fi
+
+cd $STRATIS_DEPS_DIR/stratisd
+make build
+
+# Set the PYTHONPATH to use the dependencies
+cd $STRATIS_DEPS_DIR/dbus-client-gen
+git fetch --tags
+    LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+echo "checking out $LATEST_TAG"
+git checkout $LATEST_TAG
+cd $STRATIS_DEPS_DIR/dbus-signature-pyparsing
+git pull origin master
+cd $STRATIS_DEPS_DIR/dbus-python-client-gen
+git pull origin master
+cd $STRATIS_DEPS_DIR/into-dbus-python
+git pull origin master
+cd $WORKSPACE
+export PYTHONPATH=src:$STRATIS_DEPS_DIR/dbus-client-gen/src:$STRATIS_DEPS_DIR/dbus-python-client-gen/src:$STRATIS_DEPS_DIR/into-dbus-python/src:$STRATIS_DEPS_DIR/dbus-signature-pyparsing/src
+export STRATISD=$STRATIS_DEPS_DIR/stratisd/target/x86_64-unknown-linux-gnu/debug/stratisd
+make dbus-tests

--- a/cli.sh
+++ b/cli.sh
@@ -40,18 +40,16 @@ fi
 cd $STRATIS_DEPS_DIR/stratisd
 make build
 
-# Set the PYTHONPATH to use the dependencies
-cd $STRATIS_DEPS_DIR/dbus-client-gen
-git fetch --tags
+for STRATIS_DEP in dbus-client-gen dbus-signature-pyparsing dbus-python-client-gen into-dbus-python
+do
+    cd $STRATIS_DEPS_DIR/$STRATIS_DEP
+    git fetch --tags
     LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-echo "checking out $LATEST_TAG"
-git checkout $LATEST_TAG
-cd $STRATIS_DEPS_DIR/dbus-signature-pyparsing
-git pull origin master
-cd $STRATIS_DEPS_DIR/dbus-python-client-gen
-git pull origin master
-cd $STRATIS_DEPS_DIR/into-dbus-python
-git pull origin master
+    echo "checking out $STRATIS_DEP $LATEST_TAG"
+    git checkout $LATEST_TAG
+done
+
+# Set the PYTHONPATH to use the dependencies
 cd $WORKSPACE
 export PYTHONPATH=src:$STRATIS_DEPS_DIR/dbus-client-gen/src:$STRATIS_DEPS_DIR/dbus-python-client-gen/src:$STRATIS_DEPS_DIR/into-dbus-python/src:$STRATIS_DEPS_DIR/dbus-signature-pyparsing/src
 export STRATISD=$STRATIS_DEPS_DIR/stratisd/target/x86_64-unknown-linux-gnu/debug/stratisd

--- a/cli.sh
+++ b/cli.sh
@@ -34,7 +34,7 @@ git clone https://github.com/stratis-storage/stratisd.git
 
 if [ ! -f  /etc/dbus-1/system.d/stratisd.conf ]
 then
-    cp $STRATIS_DEPS_DIR/stratisd/stratisd.conf /etc/dbus-1/system.d/.
+    cp $STRATIS_DEPS_DIR/stratisd/stratisd.conf /etc/dbus-1/system.d/
 fi
 
 cd $STRATIS_DEPS_DIR/stratisd

--- a/cli.sh
+++ b/cli.sh
@@ -3,7 +3,7 @@ set -e
 
 export PATH="$HOME/.cargo/bin:$PATH"
 
-# Jenkins will set WORKSPACE to the top level directory that contains
+# Set WORKSPACE to the top level directory that contains
 # the stratis-cli git repo
 if [ -z "$WORKSPACE" ]
 then

--- a/dm_test.sh
+++ b/dm_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Set WORKSPACE to the top level directory that contains
+# the devicemapper-rs git repo
+if [ -z "$WORKSPACE" ]
+then
+    echo "Required WORKSPACE environment variable not set"
+    exit 1
+fi
+
+cd $WORKSPACE
+
+rustup default 1.31.0
+cargo clean
+STRATIS_DESTRUCTIVE_TEST=1 make sudo_test
+

--- a/runalltests.sh
+++ b/runalltests.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Run all tests from the Stratis CI test suite
+# Current distro: Fedora (29)
+
+PRESTAGE=`pwd`
+
+dnf -y install git \
+	dbus-devel \
+	gcc \
+	systemd-devel \
+	xfsprogs \
+	python3-tox \
+	python3-pytest \
+	dbus-python \
+	make \
+	device-mapper-persistent-data \
+	xfsprogs \
+	python3-hypothesis \
+	dbus-glib-devel \
+	python3-justbytes.noarch \
+	python3-setuptools \
+	dbus-python-devel \
+	python3-pyudev \
+	python3-wcwidth \
+	python3-pyparsing \
+	dbus-devel.x86_64 \
+	systemd-devel.x86_64 \
+	glibc-devel.x86_64 \
+	dbus-devel.i686 \
+	systemd-devel.i686 \
+	glibc-devel.i686 \
+	openssl-devel
+
+# The instructions for rustup say to run "curl https://sh.rustup.rs -sSf | sh".
+# The resulting script has an interactive prompt, which would hang.
+# Instead, download it to a shell script, and execute with the "-y" switch
+# to automatically install.
+curl -o install_rustup.sh https://sh.rustup.rs
+chmod +x install_rustup.sh
+./install_rustup.sh -y
+
+source $HOME/.cargo/env
+
+# For tests that use nbd, add the following line to udev:
+# (edit /usr/lib/udev/rules.d/60-block.rules to add nbd* to remove action)
+# ACTION!="remove", SUBSYSTEM=="block", KERNEL=="loop*|nvme*|sd*|vd*|xvd*|pmem*|mmcblk*|dasd*|nbd*", OPTIONS+="watch"
+
+rustup default 1.31.0
+rustup target add i686-unknown-linux-gnu
+
+# Then, choose the directory of the test to be executed, and prep
+# the $WORKSPACE environment variable.
+# cd stratisd
+# export WORKSPACE="/root/workspace/stratisd"
+
+mkdir workspace
+cd workspace
+
+if [ -s "$HOME/test_config.json" ]
+then
+	STRATISD_MODE="test-real"
+else
+	STRATISD_MODE="test-loop"
+fi
+echo "Executing stratisd test ($STRATISD_MODE)"
+git clone https://github.com/stratis-storage/stratisd.git
+cd stratisd
+export WORKSPACE=`pwd`
+$PRESTAGE/stratisd.sh $STRATISD_MODE
+RC_STRATISD=$?
+echo "Completed stratisd test ($STRATISD_MODE): status $RC_STRATISD"
+cd $PRESTAGE/workspace
+
+echo "Executing stratis-cli test..."
+git clone https://github.com/stratis-storage/stratis-cli
+cd stratis-cli
+export WORKSPACE=`pwd`
+$PRESTAGE/cli.sh
+RC_STRATISCLI=$?
+echo "Completed stratis-cli test: status $RC_STRATISCLI"
+cd $PRESTAGE/workspace
+
+echo "Executing devicemapper-rs test..."
+git clone https://github.com/stratis-storage/devicemapper-rs.git
+cd devicemapper-rs
+export WORKSPACE=`pwd`
+$PRESTAGE/dm_test.sh
+RC_DEVMAPPER=$?
+echo "Completed devicemapper-rs test: status $RC_DEVMAPPER"
+cd $PRESTAGE/workspace
+
+echo "End of prestage script."
+echo "Results:"
+echo "stratisd-$STRATISD_MODE: $RC_STRATISD"
+echo "stratis-cli: $RC_STRATISCLI"
+echo "devicemapper-rs: $RC_DEVMAPPER"

--- a/stratisd.sh
+++ b/stratisd.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -e
+
+export PATH="$HOME/.cargo/bin:$PATH"
+export STRATIS_DEPS_DIR=$WORKSPACE/stratis-deps
+export RUST_LOG=libstratis=debug
+export TEST_BLOCKDEVS_FILE=~/test_config.json
+
+TARGET=$1
+
+if [ -z $TARGET ]
+then
+   echo "Usage: $0 test-loop | test-real"
+   exit 1
+fi
+
+# Set WORKSPACE to the top level directory that contains the stratisd git repo
+if [ -z $WORKSPACE ]
+then
+    echo "Required WORKSPACE variable not set. Set WORKSPACE to directory that contains"
+    echo "stratisd git repo."
+    exit 1
+fi
+
+if [ ! -d $WORKSPACE/tests/ ]
+then
+    echo "$WORKSPACE/tests/ does not exist.  Verify WORKSPACE is set to correct directory."
+    exit 1
+fi
+
+# Each CI system must have a TEST_BLOCKDEVS_FILE file populated with
+# block devices that are safe to use/overwrite on the system.
+# Only check for this for "make test-real".
+if [ $TARGET == "test-real" ]
+then
+    if [ -s "$TEST_BLOCKDEVS_FILE" ]
+    then
+        cp $TEST_BLOCKDEVS_FILE $WORKSPACE/tests/.
+    else
+        echo "Required file $TEST_BLOCKDEVS_FILE not found."
+        exit 1
+    fi
+fi
+
+cd $WORKSPACE
+rustup default 1.31.0
+cargo clean
+make build
+make $TARGET
+
+# 32 bit build
+rustup target add i686-unknown-linux-gnu
+TARGET=i686-unknown-linux-gnu make build
+
+# If there is a stale STRATIS_DEPS_DIR remove it
+if [ -d $STRATIS_DEPS_DIR ]
+then
+    rm -rf $STRATIS_DEPS_DIR
+fi
+
+if [ -d $WORKSPACE/tests/client-dbus ]
+then
+    echo "Running client-dbus tests"
+    export STRATISD=$WORKSPACE/target/x86_64-unknown-linux-gnu/debug/stratisd
+
+    if [ ! -f  /etc/dbus-1/system.d/stratisd.conf ]
+    then
+        cp $WORKSPACE/stratisd.conf /etc/dbus-1/system.d/.
+    fi
+
+
+    if [ ! -x $STRATISD ]
+    then
+        echo "Required $STRATISD not not found or not executable"
+        exit 1
+    fi
+
+    mkdir $STRATIS_DEPS_DIR
+    cd $STRATIS_DEPS_DIR
+
+    # Clone the python dependencies
+    git clone https://github.com/stratis-storage/dbus-python-client-gen.git
+    git clone https://github.com/stratis-storage/dbus-client-gen.git
+    git clone https://github.com/stratis-storage/into-dbus-python.git
+    git clone https://github.com/stratis-storage/dbus-signature-pyparsing.git
+
+    # Set the PYTHONPATH to use the dependencies
+    export PYTHONPATH=src:$STRATIS_DEPS_DIR/dbus-client-gen/src:$STRATIS_DEPS_DIR/dbus-python-client-gen/src:$STRATIS_DEPS_DIR/into-dbus-python/src:$STRATIS_DEPS_DIR/dbus-signature-pyparsing/src
+    export STRATISD=$WORKSPACE/target/x86_64-unknown-linux-gnu/debug/stratisd
+    cd $STRATIS_DEPS_DIR/dbus-client-gen
+    git fetch --tags
+        LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+        echo "checking out $LATEST_TAG"
+        git checkout $LATEST_TAG
+    cd $STRATIS_DEPS_DIR/dbus-signature-pyparsing
+    git pull origin master
+    cd $STRATIS_DEPS_DIR/dbus-python-client-gen
+    git pull origin master
+    cd $STRATIS_DEPS_DIR/into-dbus-python
+    git pull origin master
+    cd $WORKSPACE/tests/client-dbus
+    make tests
+else
+    echo "client-dbus directory does not exist: $WORKSPACE/tests/client-dbus"
+fi

--- a/stratisd.sh
+++ b/stratisd.sh
@@ -84,20 +84,19 @@ then
     git clone https://github.com/stratis-storage/into-dbus-python.git
     git clone https://github.com/stratis-storage/dbus-signature-pyparsing.git
 
+    for STRATIS_DEP in dbus-client-gen dbus-signature-pyparsing dbus-python-client-gen into-dbus-python
+    do
+        cd $STRATIS_DEPS_DIR/$STRATIS_DEP
+        git fetch --tags
+        LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+        echo "checking out $STRATIS_DEP $LATEST_TAG"
+        git checkout $LATEST_TAG
+    done
     # Set the PYTHONPATH to use the dependencies
     export PYTHONPATH=src:$STRATIS_DEPS_DIR/dbus-client-gen/src:$STRATIS_DEPS_DIR/dbus-python-client-gen/src:$STRATIS_DEPS_DIR/into-dbus-python/src:$STRATIS_DEPS_DIR/dbus-signature-pyparsing/src
     export STRATISD=$WORKSPACE/target/x86_64-unknown-linux-gnu/debug/stratisd
     cd $STRATIS_DEPS_DIR/dbus-client-gen
-    git fetch --tags
-        LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-        echo "checking out $LATEST_TAG"
-        git checkout $LATEST_TAG
-    cd $STRATIS_DEPS_DIR/dbus-signature-pyparsing
-    git pull origin master
-    cd $STRATIS_DEPS_DIR/dbus-python-client-gen
-    git pull origin master
-    cd $STRATIS_DEPS_DIR/into-dbus-python
-    git pull origin master
+
     cd $WORKSPACE/tests/client-dbus
     make tests
 else

--- a/stratisd.sh
+++ b/stratisd.sh
@@ -65,7 +65,7 @@ then
 
     if [ ! -f  /etc/dbus-1/system.d/stratisd.conf ]
     then
-        cp $WORKSPACE/stratisd.conf /etc/dbus-1/system.d/.
+        cp $WORKSPACE/stratisd.conf /etc/dbus-1/system.d/
     fi
 
 


### PR DESCRIPTION
Add a test script that calls all tests in the continuous integration
suite (as well as the test scripts themselves):

- stratisd: stratisd
-- (If no test_config.json file exists, "test-loop" is executed.)
-- (If a test_config.json file exists, "test-real" is executed.)
- cli.sh: stratis-cli
- dm_test: devicemapper-rs

The test installs all required packages (currently based on Fedora
29), installs upstream rust, and creates a working directory called
"workspace".

Signed-off-by: Bryan Gurney <bgurney@redhat.com>