### PR TITLE
Change CI scripts corresponding with changes in stratisd Makefile

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -52,5 +52,5 @@ done
 # Set the PYTHONPATH to use the dependencies
 cd $WORKSPACE
 export PYTHONPATH=src:$STRATIS_DEPS_DIR/dbus-client-gen/src:$STRATIS_DEPS_DIR/dbus-python-client-gen/src:$STRATIS_DEPS_DIR/into-dbus-python/src:$STRATIS_DEPS_DIR/dbus-signature-pyparsing/src
-export STRATISD=$STRATIS_DEPS_DIR/stratisd/target/x86_64-unknown-linux-gnu/debug/stratisd
+export STRATISD=$STRATIS_DEPS_DIR/stratisd/target/debug/stratisd
 make dbus-tests

--- a/runalltests.sh
+++ b/runalltests.sh
@@ -47,7 +47,6 @@ source $HOME/.cargo/env
 # ACTION!="remove", SUBSYSTEM=="block", KERNEL=="loop*|nvme*|sd*|vd*|xvd*|pmem*|mmcblk*|dasd*|nbd*", OPTIONS+="watch"
 
 rustup default 1.31.0
-rustup target add i686-unknown-linux-gnu
 
 # Then, choose the directory of the test to be executed, and prep
 # the $WORKSPACE environment variable.

--- a/stratisd.sh
+++ b/stratisd.sh
@@ -45,8 +45,10 @@ fi
 cd $WORKSPACE
 rustup default 1.31.0
 cargo clean
-make build
 make $TARGET
+
+# Make a build in order to run test outside the Rust framework
+make build
 
 # If there is a stale STRATIS_DEPS_DIR remove it
 if [ -d $STRATIS_DEPS_DIR ]

--- a/stratisd.sh
+++ b/stratisd.sh
@@ -48,10 +48,6 @@ cargo clean
 make build
 make $TARGET
 
-# 32 bit build
-rustup target add i686-unknown-linux-gnu
-TARGET=i686-unknown-linux-gnu make build
-
 # If there is a stale STRATIS_DEPS_DIR remove it
 if [ -d $STRATIS_DEPS_DIR ]
 then

--- a/stratisd.sh
+++ b/stratisd.sh
@@ -59,7 +59,7 @@ fi
 if [ -d $WORKSPACE/tests/client-dbus ]
 then
     echo "Running client-dbus tests"
-    export STRATISD=$WORKSPACE/target/x86_64-unknown-linux-gnu/debug/stratisd
+    export STRATISD=$WORKSPACE/target/debug/stratisd
 
     if [ ! -f  /etc/dbus-1/system.d/stratisd.conf ]
     then
@@ -92,7 +92,6 @@ then
     done
     # Set the PYTHONPATH to use the dependencies
     export PYTHONPATH=src:$STRATIS_DEPS_DIR/dbus-client-gen/src:$STRATIS_DEPS_DIR/dbus-python-client-gen/src:$STRATIS_DEPS_DIR/into-dbus-python/src:$STRATIS_DEPS_DIR/dbus-signature-pyparsing/src
-    export STRATISD=$WORKSPACE/target/x86_64-unknown-linux-gnu/debug/stratisd
     cd $STRATIS_DEPS_DIR/dbus-client-gen
 
     cd $WORKSPACE/tests/client-dbus


### PR DESCRIPTION
The Makefile does not set the default Rust compiler target, instead leaving the choice to cargo.