### PR TITLE
ci: add dnf install python3-dateutil

### DIFF
--- a/runalltests.sh
+++ b/runalltests.sh
@@ -22,6 +22,7 @@ dnf -y install git \
 	python3-setuptools \
 	dbus-python-devel \
 	python3-pyudev \
+	python3-dateutil \
 	python3-wcwidth \
 	python3-pyparsing \
 	dbus-devel.x86_64 \


### PR DESCRIPTION
The python3-dateutil package is needed for the CI tests.

On testing the scripts on a system with less packages installed, the
stratis-cli whitebox tests reported failures caused by the dateutil
package not being installed.  Therefore, add them to the "dnf install"
command.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>