### PR TITLE
ci: update rustup to 1.35.0

### DIFF
--- a/dm_test.sh
+++ b/dm_test.sh
@@ -13,7 +13,7 @@ fi
 
 cd $WORKSPACE
 
-rustup default 1.31.0
+rustup default 1.35.0
 cargo clean
 STRATIS_DESTRUCTIVE_TEST=1 make sudo_test
 

--- a/runalltests.sh
+++ b/runalltests.sh
@@ -47,7 +47,7 @@ source $HOME/.cargo/env
 # (edit /usr/lib/udev/rules.d/60-block.rules to add nbd* to remove action)
 # ACTION!="remove", SUBSYSTEM=="block", KERNEL=="loop*|nvme*|sd*|vd*|xvd*|pmem*|mmcblk*|dasd*|nbd*", OPTIONS+="watch"
 
-rustup default 1.31.0
+rustup default 1.35.0
 
 # Then, choose the directory of the test to be executed, and prep
 # the $WORKSPACE environment variable.

--- a/stratisd.sh
+++ b/stratisd.sh
@@ -43,7 +43,7 @@ then
 fi
 
 cd $WORKSPACE
-rustup default 1.31.0
+rustup default 1.35.0
 cargo clean
 make $TARGET
 


### PR DESCRIPTION
Update the rustup default to 1.35.0, to match the corresponding
changes in the stratisd and devicemapper-rs tests.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>