### PR TITLE
runalltests: add make to dnf install command

### DIFF
--- a/runalltests.sh
+++ b/runalltests.sh
@@ -6,6 +6,7 @@
 PRESTAGE=`pwd`
 
 dnf -y install git \
+	make \
 	dbus-devel \
 	gcc \
 	systemd-devel \


### PR DESCRIPTION
Some systems might not have make installed, therefore try to
install it.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>