### PR TITLE
stratisd.sh: remove client-dbus and udev tests

### DIFF
--- a/stratisd.sh
+++ b/stratisd.sh
@@ -2,7 +2,6 @@
 set -e
 
 export PATH="$HOME/.cargo/bin:$PATH"
-export STRATIS_DEPS_DIR=$WORKSPACE/stratis-deps
 export RUST_LOG=libstratis=debug
 export TEST_BLOCKDEVS_FILE=~/test_config.json
 
@@ -46,56 +45,3 @@ cd $WORKSPACE
 rustup default 1.35.0
 cargo clean
 make $TARGET
-
-# Make a build in order to run test outside the Rust framework
-make build
-
-# If there is a stale STRATIS_DEPS_DIR remove it
-if [ -d $STRATIS_DEPS_DIR ]
-then
-    rm -rf $STRATIS_DEPS_DIR
-fi
-
-if [ -d $WORKSPACE/tests/client-dbus ]
-then
-    echo "Running client-dbus tests"
-    export STRATISD=$WORKSPACE/target/debug/stratisd
-
-    if [ ! -f  /etc/dbus-1/system.d/stratisd.conf ]
-    then
-        cp $WORKSPACE/stratisd.conf /etc/dbus-1/system.d/
-    fi
-
-
-    if [ ! -x $STRATISD ]
-    then
-        echo "Required $STRATISD not not found or not executable"
-        exit 1
-    fi
-
-    mkdir $STRATIS_DEPS_DIR
-    cd $STRATIS_DEPS_DIR
-
-    # Clone the python dependencies
-    git clone https://github.com/stratis-storage/dbus-python-client-gen.git
-    git clone https://github.com/stratis-storage/dbus-client-gen.git
-    git clone https://github.com/stratis-storage/into-dbus-python.git
-    git clone https://github.com/stratis-storage/dbus-signature-pyparsing.git
-
-    for STRATIS_DEP in dbus-client-gen dbus-signature-pyparsing dbus-python-client-gen into-dbus-python
-    do
-        cd $STRATIS_DEPS_DIR/$STRATIS_DEP
-        git fetch --tags
-        LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-        echo "checking out $STRATIS_DEP $LATEST_TAG"
-        git checkout $LATEST_TAG
-    done
-    # Set the PYTHONPATH to use the dependencies
-    export PYTHONPATH=src:$STRATIS_DEPS_DIR/dbus-client-gen/src:$STRATIS_DEPS_DIR/dbus-python-client-gen/src:$STRATIS_DEPS_DIR/into-dbus-python/src:$STRATIS_DEPS_DIR/dbus-signature-pyparsing/src
-    cd $STRATIS_DEPS_DIR/dbus-client-gen
-
-    cd $WORKSPACE/tests/client-dbus
-    make tests
-else
-    echo "client-dbus directory does not exist: $WORKSPACE/tests/client-dbus"
-fi


### PR DESCRIPTION
The client-dbus tests and udev tests (also known as the "non-rust
tests") take about 6 minutes to run, and therefore add a lot of time
to the stratisd.sh test run when executed on real devices.  These
tests are now in their own script, in the stratisd_nonrust.sh file.

Remove these tests from the main stratisd.sh script.  In a test run,
this reduced the run time from over 12 minutes to about 6.5 minutes.

NOTE: After this point, to test all of stratisd, both the stratisd.sh
and stratisd_nonrust.sh scripts must be executed.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>