### PR TITLE
ci: add teardown script for stratisd test

### DIFF
--- a/teardown.sh
+++ b/teardown.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+echo "Terminating test processes:"
+ps -ef | egrep 'stratisd.sh|make|cargo|libstratis|PPID' | grep -v grep
+ps aux | egrep 'stratisd.sh|make|cargo|libstratis|RSS' | grep -v grep
+pkill 'stratisd.sh|make|cargo|libstratis'
+pkill 'stratisd.sh|make|cargo|libstratis'
+for j in $(ps aux | grep target/debug/stratisd\ --sim | grep -v grep | awk '{print $2}')
+do 
+	echo "Terminating target/debug/stratisd --sim process $j"
+	kill $j
+done
+echo
+
+# Wait for a few seconds for the I/O to finish.
+sleep 4
+
+lsblk -i
+dmsetup info -c
+
+# If the thin-pool devices are suspended, the next steps will fail.
+# Therefore, resume them now.
+# (If they're not suspended, nothing will happen.)
+for i in thinpool-pool
+do
+	for j in $(dmsetup ls | grep $i | awk {'print $1'})
+	do
+		echo "Ensuring thin-pool device is not suspended"
+		dmsetup resume $j
+		echo
+	done
+done
+
+# Now tear down the remnant stratis component devices, top to bottom.
+for i in thin-fs thinpool-pool flex-thinmeta flex-thindata flex-mdv physical-originsub stratis_test_
+do
+	for j in $(dmsetup ls | grep $i | awk {'print $1'})
+	do
+		echo "Removing device:"
+		dmsetup info -c $j
+		dmsetup table $j
+		dmsetup remove $j
+		echo
+	done
+done
+
+for testdevs in $(grep /dev ~/test_config.json | tr -d \"\,)
+do
+	for wipetgt in $(blkid -p $testdevs | grep stratis | awk '{print $1}' | tr -d \:)
+	do
+		echo "Wiping signature on $wipetgt:"
+		wipefs -a $wipetgt
+	done
+done
+


### PR DESCRIPTION
If the "stratisd.sh test-real" test is terminated in mid-run,
there may be a remnant Stratis pool left on the test devices,
potentially with a thin-pool that was left suspended.

This test in particular seems to leave a device behind in that state:

engine::strat_engine::pool::tests::real_test_add_datadevs

The "thinpool-pool" device undergoes a high frequency of
suspend-reload-resume activity during this test.  If it isn't
resumed, it may cause a process to go into uninterruptible sleep,
resulting in devices that can't be removed, and requiring a restart
of the test system.

The script terminates any test processes (including "stratisd --sim"
processes left over from devicemapper-rs tests), resumes the testing
"thinpool-pool" devices, and removes the devices in the Stratis
pool, top to bottom.  After that, any block devices specified in the
test_config.json file are wiped clean of signatures, via "wipefs -a".

Signed-off-by: Bryan Gurney <bgurney@redhat.com>