### PR TITLE
ci: add info for testing real devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,24 @@ Note that the "runalltests.sh" script will clone the "stratisd", "stratis-cli", 
 "stratisd.sh": stratisd test suite CI script (for the rust tests)
 
 "stratisd_nonrust.sh": stratisd test suite CI script (for the client-dbus tests)
+
+# Running the stratisd test with real devices
+
+To run the stratisd test with scratch test devices, create the file `test_config.json` in the home directory of the user calling the "runalltests.sh" script.
+
+The stratisd test requires four scratch devices, which should be at least about 8 GiB in size.
+
+The contents of the `test_config.json` file should be a JSON array of paths to the scratch devices.  For example:
+
+```
+{
+    "ok_to_destroy_dev_array_key": [
+    				   "/dev/vdb",
+    				   "/dev/vdc",
+    				   "/dev/vdd",
+    				   "/dev/vde"
+    ]
+}
+```
+
+Be sure that the last item in the array does not have a trailing comma.


### PR DESCRIPTION
Add the information for running the stratisd test with real devices,
including a sample test_config.json file.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>