### PR TITLE
ci: add python3-psutil to dnf install command

### DIFF
--- a/runalltests.sh
+++ b/runalltests.sh
@@ -26,6 +26,7 @@ dnf -y install git \
 	python3-dateutil \
 	python3-wcwidth \
 	python3-pyparsing \
+	python3-psutil \
 	dbus-devel.x86_64 \
 	systemd-devel.x86_64 \
 	glibc-devel.x86_64 \


### PR DESCRIPTION
It turns out that the Fedora Cloud image has python3-psutil
installed by default, but a fresh Fedora Workstation install
does not have it installed.  Therefore, add python3-psutil
to the list of packages to install via the "dnf install"
command.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>