### PR TITLE
ci: move test_config.json file to /etc/stratis

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Note that the "runalltests.sh" script will clone the "stratisd", "stratis-cli", 
 
 # Running the stratisd test with real devices
 
-To run the stratisd test with scratch test devices, create the file `test_config.json` in the home directory of the user calling the "runalltests.sh" script.
+To run the stratisd test with scratch test devices, create the file `/etc/stratis/test_config.json`.
 
 The stratisd test requires four scratch devices, which should be at least about 8 GiB in size.
 

--- a/runalltests.sh
+++ b/runalltests.sh
@@ -55,7 +55,7 @@ rustup default 1.36.0
 mkdir workspace
 cd workspace
 
-if [ -s "$HOME/test_config.json" ]
+if [ -s "/etc/stratis/test_config.json" ]
 then
 	STRATISD_MODE="test-real"
 else

--- a/stratisd.sh
+++ b/stratisd.sh
@@ -3,7 +3,7 @@ set -e
 
 export PATH="$HOME/.cargo/bin:$PATH"
 export RUST_LOG=libstratis=debug
-export TEST_BLOCKDEVS_FILE=~/test_config.json
+export TEST_BLOCKDEVS_FILE=/etc/stratis/test_config.json
 
 TARGET=$1
 

--- a/teardown.sh
+++ b/teardown.sh
@@ -43,7 +43,7 @@ do
 	done
 done
 
-for testdevs in $(grep /dev ~/test_config.json | tr -d \"\,)
+for testdevs in $(grep /dev /etc/stratis/test_config.json | tr -d \"\,)
 do
 	for wipetgt in $(blkid -p $testdevs | grep stratis | awk '{print $1}' | tr -d \:)
 	do


### PR DESCRIPTION
Placing the test_config.json file in the calling user's home
directory creates problems when /etc/sudoers has the default option
"always_set_home" enabled.  Therefore, relocate the test_config.json
file to a standard location of /etc/stratis/test_config.json.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>