### PR TITLE
ci: add blackbox test runner script

### DIFF
--- a/blackbox/README.md
+++ b/blackbox/README.md
@@ -1,0 +1,21 @@
+# Stratis blackbox test run script
+
+The stratis-blackbox-run.sh script builds a set of testing RPM packages of the stratisd and stratis-cli master branches, runs a series of "blackbox" tests against the version of Stratis installed by these packages, and then uninstalls the packages.
+
+The blackbox test requires three scratch devices, loaded from the `/etc/stratis/test_config.json` file, which contains a JSON array of paths to the scratch devices.
+
+Example `/etc/stratis/test_config.json` file:
+
+```
+{
+    "ok_to_destroy_dev_array_key": [
+                                   "/dev/vdb",
+                                   "/dev/vdc",
+                                   "/dev/vdd",
+    ]
+}
+```
+
+The RPMs are built with spec files that originate from the RHEL source RPMs, with one key modification: the version number and changelog dates are set in the future, for testing purposes.
+
+This blackbox test is intended to execute on a Red Hat Enterprise Linux test system.

--- a/blackbox/stratis-blackbox-run.sh
+++ b/blackbox/stratis-blackbox-run.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -e
+
+if [ ! -e /etc/stratis/test_config.json ]
+then
+	echo "No test device config found; create a ~/test_config.json"
+	echo "file with three devices that can be overwritten for testing."
+	exit 8
+fi
+
+# Create an array of test devices from the ~/test_config.json file.
+# This is a naive search for device paths starting with "/dev", then
+# stripping out the quote and comma characters.
+TESTDEVS=($(grep \/dev /etc/stratis/test_config.json | tr -d \"\,))
+
+if [ ! -e stratisd.spec -o ! -e stratis-cli.spec ]
+then
+	echo "Both stratisd.spec and stratis-cli.spec must be present."
+	exit 4
+fi
+
+STRATISD_REPO="https://github.com/stratis-storage/stratisd.git"
+STRATIS_CLI_REPO="https://github.com/stratis-storage/stratis-cli.git"
+
+BASEDEPPKGS=(
+	python3-dbus-client-gen
+	python3-dbus-python-client-gen
+	python3-justbytes
+	rpm-build
+	rpmdevtools
+	asciidoc
+	python3-devel
+	dbus-devel
+	rust-toolset
+	systemd-devel
+	rust
+	cargo
+	openssl-devel
+	make
+)
+
+dnf -y install "${BASEDEPPKGS[@]}"
+
+STRATISD_N=$(rpmspec -P stratisd.spec | grep ^Name | awk {'print $2'})
+STRATISD_V=$(rpmspec -P stratisd.spec | grep ^Version | awk {'print $2'})
+STRATISD_R=$(rpmspec -P stratisd.spec | grep ^Release | awk {'print $2'})
+STRATISD_RPMBASENAME="${STRATISD_N}-${STRATISD_V}-${STRATISD_R}"
+echo "stratisd package target: $STRATISD_RPMBASENAME"
+STRATIS_CLI_N=$(rpmspec -P stratis-cli.spec | grep ^Name | awk {'print $2'})
+STRATIS_CLI_V=$(rpmspec -P stratis-cli.spec | grep ^Version | awk {'print $2'})
+STRATIS_CLI_R=$(rpmspec -P stratis-cli.spec | grep ^Release | awk {'print $2'})
+STRATIS_CLI_RPMBASENAME="${STRATIS_CLI_N}-${STRATIS_CLI_V}-${STRATIS_CLI_R}"
+echo "stratis-cli package target: $STRATIS_CLI_RPMBASENAME"
+
+if [ -d output_rpms ]
+then
+	echo "output_rpms directory already exists.  Recreating..."
+	rm -rvf output_rpms
+fi
+mkdir output_rpms
+mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS}/
+
+# Remove the previously created repository directories
+rm -rf ${STRATISD_N}-${STRATISD_V}
+rm -rf ${STRATIS_CLI_N}-${STRATIS_CLI_V}
+
+
+# Build the stratisd package (along with the rust cargo vendor tarball)
+echo "Building stratisd test package..."
+git clone $STRATISD_REPO
+mv -v ${STRATISD_N} ${STRATISD_N}-${STRATISD_V}
+mkdir ${STRATISD_N}-${STRATISD_V}/vendor
+tar czvf ~/rpmbuild/SOURCES/${STRATISD_N}-${STRATISD_V}.tar.gz ${STRATISD_N}-${STRATISD_V}
+cd ${STRATISD_N}-${STRATISD_V}/
+cargo vendor && tar cJf ../${STRATISD_N}-${STRATISD_V}-vendor.tar.xz vendor/
+cd ..
+cp ${STRATISD_N}-${STRATISD_V}-vendor.tar.xz ~/rpmbuild/SOURCES
+echo "Executing rpmbuild for stratisd..."
+rpmbuild -bb stratisd.spec
+
+# Build the stratis-cli package
+echo "Building stratis-cli test package..."
+git clone $STRATIS_CLI_REPO
+mv -v ${STRATIS_CLI_N} ${STRATIS_CLI_N}-${STRATIS_CLI_V}
+tar czvf ~/rpmbuild/SOURCES/${STRATIS_CLI_N}-${STRATIS_CLI_V}.tar.gz ${STRATIS_CLI_N}-${STRATIS_CLI_V}
+echo "Executing rpmbuild for stratis-cli..."
+rpmbuild -bb stratis-cli.spec
+
+# Find all of the stratis-related RPM files output via the rpmbuild
+# stage, (including debuginfo and debugsource), and copy them to the
+# staging directory.
+find ~/rpmbuild/RPMS/ -name stratis*.rpm -exec cp -v {} output_rpms/ \;
+
+dnf -y install output_rpms/$STRATISD_RPMBASENAME*.rpm output_rpms/$STRATIS_CLI_RPMBASENAME*.rpm
+
+# Start running blackbox tests.
+echo "----------"
+echo "Test devices: ${TESTDEVS[0]} ${TESTDEVS[1]} ${TESTDEVS[2]}"
+echo "Executing stratis-cli blackbox tests..."
+python3 stratis-cli-1.0.9/tests/blackbox/stratis_cli_cert.py -v --disk ${TESTDEVS[0]} --disk ${TESTDEVS[1]} --disk ${TESTDEVS[2]}
+
+echo "----------"
+echo "Test devices: ${TESTDEVS[0]} ${TESTDEVS[1]} ${TESTDEVS[2]}"
+echo "Executing stratisd blackbox tests..."
+python3 stratis-cli-1.0.9/tests/blackbox/stratisd_cert.py -v --disk ${TESTDEVS[0]} --disk ${TESTDEVS[1]} --disk ${TESTDEVS[2]}
+
+echo "----------"
+echo "Cleaning rpmbuild directories"
+
+rm -rfv ~/rpmbuild/RPMS/*
+rm -rfv ~/rpmbuild/SOURCES/*
+rm -rfv ~/rpmbuild/SPECS/*
+
+dnf -y remove $STRATISD_RPMBASENAME $STRATIS_CLI_RPMBASENAME

--- a/blackbox/stratis-cli.spec
+++ b/blackbox/stratis-cli.spec
@@ -1,0 +1,55 @@
+
+Name:           stratis-cli
+Version:        1.0.9
+Release:        9%{?dist}
+Summary:        Command-line tool for interacting with the Stratis daemon
+
+License:        ASL 2.0
+URL:            https://github.com/stratis-storage/stratis-cli
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  %{_bindir}/a2x
+# It runs without, but totally useless
+#Requires:       (stratisd >= 1.0 with stratisd < 1.1)
+
+# stratisd only available on certain arches
+ExclusiveArch:  %{rust_arches} noarch
+BuildArch:      noarch
+
+%description
+Stratis-cli test build.  This package should not be used in production
+
+%prep
+%autosetup
+
+%build
+%py3_build
+a2x -f manpage docs/stratis.txt
+
+%install
+%py3_install
+%{__install} -Dpm0644 -t %{buildroot}%{_datadir}/bash-completion/completions \
+  shell-completion/bash/stratis
+%{__install} -Dpm0644 -t %{buildroot}%{_datadir}/zsh/site-functions \
+  shell-completion/zsh/_stratis
+%{__install} -Dpm0644 -t %{buildroot}%{_mandir}/man8 docs/stratis.8
+
+%files
+%license LICENSE
+%doc README.rst
+%{_bindir}/stratis
+%{_mandir}/man8/stratis.8*
+%dir %{_datadir}/bash-completion
+%dir %{_datadir}/bash-completion/completions
+%{_datadir}/bash-completion/completions/stratis
+%dir %{_datadir}/zsh
+%dir %{_datadir}/zsh/site-functions
+%{_datadir}/zsh/site-functions/_stratis
+%{python3_sitelib}/stratis_cli/
+%{python3_sitelib}/stratis_cli-*.egg-info/
+
+%changelog
+* Fri Mar 22 2233 Stratis Team <stratis-team@redhat.com> - 1.0.9-9
+- Update to 1.0.9-9

--- a/blackbox/stratisd.spec
+++ b/blackbox/stratisd.spec
@@ -1,0 +1,78 @@
+%bcond_without check
+
+# Not interested in packaging lib
+# stratisd is supposed to be daemon used through dbus
+%global __cargo_is_lib() false
+
+Name:           stratisd
+Version:        1.0.9
+Release:        9%{?dist}
+Summary:        Daemon that manages block devices to create filesystems
+
+License:        MPLv2.0
+URL:            https://github.com/stratis-storage/stratisd
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+Source1:        %{name}-%{version}-vendor.tar.xz
+
+
+ExclusiveArch:  %{rust_arches}
+
+BuildRequires:  rust-toolset
+BuildRequires:  systemd-devel
+BuildRequires:  dbus-devel
+BuildRequires:  %{_bindir}/a2x
+
+Requires:       xfsprogs
+Requires:       device-mapper-persistent-data
+Requires:       systemd-libs
+Requires:       dbus-libs
+
+%description
+Stratisd test build.  This package should not be used in production
+
+
+%prep
+%setup -q -n %{name}-%{version}
+
+# Source1 is vendored dependencies
+%cargo_prep -V 1
+
+%build
+%cargo_build
+a2x -f manpage docs/stratisd.txt
+
+%install
+%cargo_install
+%{__install} -Dpm0644 -t %{buildroot}%{_datadir}/dbus-1/system.d stratisd.conf
+# Daemon should be really private
+mkdir -p %{buildroot}%{_libexecdir}
+mv %{buildroot}%{_bindir}/stratisd %{buildroot}%{_libexecdir}/stratisd
+%{__install} -Dpm0644 -t %{buildroot}%{_mandir}/man8 docs/stratisd.8
+%{__install} -Dpm0644 -t %{buildroot}%{_unitdir} stratisd.service
+
+%if %{with check}
+%check
+%cargo_test -- --skip real_ --skip loop_ --skip travis_
+%endif
+
+%post
+%systemd_post stratisd.service
+
+%preun
+%systemd_preun stratisd.service
+
+%postun
+%systemd_postun_with_restart stratisd.service
+
+%files
+%license LICENSE
+%doc README.md
+%{_libexecdir}/stratisd
+%dir %{_datadir}/dbus-1
+%{_datadir}/dbus-1/system.d/stratisd.conf
+%{_mandir}/man8/stratisd.8*
+%{_unitdir}/stratisd.service
+
+%changelog
+* Fri Mar 22 2233 Stratis Team <stratis-team@redhat.com> - 1.0.9-9
+- Update to 1.0.9-9


### PR DESCRIPTION
Add a "blackbox" test runner script, along with the necessary
spec files to create the stratisd and stratis-cli RPM packages.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>