### PR TITLE
ci blackbox: Fix JSON example in README.md

### DIFF
--- a/blackbox/README.md
+++ b/blackbox/README.md
@@ -11,7 +11,7 @@ Example `/etc/stratis/test_config.json` file:
     "ok_to_destroy_dev_array_key": [
                                    "/dev/vdb",
                                    "/dev/vdc",
-                                   "/dev/vdd",
+                                   "/dev/vdd"
     ]
 }
 ```


### PR DESCRIPTION
The last element in the test_config.json JSON should not have a
comma.  Remove the trailing comma in the last element of the
device list.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>