### PR TITLE
ci blackbox: continue script run on test failures

### DIFF
--- a/blackbox/stratis-blackbox-run.sh
+++ b/blackbox/stratis-blackbox-run.sh
@@ -101,12 +101,12 @@ dnf -y install output_rpms/$STRATISD_RPMBASENAME*.rpm output_rpms/$STRATIS_CLI_R
 echo "----------"
 echo "Test devices: ${TESTDEVS[0]} ${TESTDEVS[1]} ${TESTDEVS[2]}"
 echo "Executing blackbox test 'python3 stratis_cli_cert.py' against test devices..."
-python3 stratis-cli-1.0.9/tests/blackbox/stratis_cli_cert.py -v --disk ${TESTDEVS[0]} --disk ${TESTDEVS[1]} --disk ${TESTDEVS[2]}
+python3 stratis-cli-1.0.9/tests/blackbox/stratis_cli_cert.py -v --disk ${TESTDEVS[0]} --disk ${TESTDEVS[1]} --disk ${TESTDEVS[2]} || echo "Test failed: stratis_cli_cert"
 
 echo "----------"
 echo "Test devices: ${TESTDEVS[0]} ${TESTDEVS[1]} ${TESTDEVS[2]}"
 echo "Executing blackbox test 'python3 stratisd_cert.py' against test devices..."
-python3 stratis-cli-1.0.9/tests/blackbox/stratisd_cert.py -v --disk ${TESTDEVS[0]} --disk ${TESTDEVS[1]} --disk ${TESTDEVS[2]}
+python3 stratis-cli-1.0.9/tests/blackbox/stratisd_cert.py -v --disk ${TESTDEVS[0]} --disk ${TESTDEVS[1]} --disk ${TESTDEVS[2]} || echo "Test failed: stratisd_cert"
 
 echo "----------"
 echo "Cleaning rpmbuild directories"


### PR DESCRIPTION
Since the blackbox test runner script runs with "set -e", any
failure will cause the script execution to fail.  However, if a test
fails, it will prevent the generated RPM packages from being removed,
since the "dnf remove" command is after the tests.

Bypass this by using "||" to print a "Test failed" message if the
test fails.  Use this for the stratis_cli_cert and stratisd_cert test
suites.

Signed-off-by: Bryan Gurney <bgurney@redhat.com>