### PR TITLE
ci blackbox: advance artificial stratisd/stratis-cli version number

### DIFF
--- a/blackbox/stratis-cli.spec
+++ b/blackbox/stratis-cli.spec
@@ -1,7 +1,7 @@
 
 Name:           stratis-cli
-Version:        1.0.9
-Release:        9%{?dist}
+Version:        77.77.77
+Release:        77%{?dist}
 Summary:        Command-line tool for interacting with the Stratis daemon
 
 License:        ASL 2.0
@@ -51,5 +51,5 @@ a2x -f manpage docs/stratis.txt
 %{python3_sitelib}/stratis_cli-*.egg-info/
 
 %changelog
-* Fri Mar 22 2233 Stratis Team <stratis-team@redhat.com> - 1.0.9-9
-- Update to 1.0.9-9
+* Fri Mar 22 2233 Stratis Team <stratis-team@redhat.com> - 77.77.77-77
+- Update to 77.77.77-77

--- a/blackbox/stratisd.spec
+++ b/blackbox/stratisd.spec
@@ -5,8 +5,8 @@
 %global __cargo_is_lib() false
 
 Name:           stratisd
-Version:        1.0.9
-Release:        9%{?dist}
+Version:        77.77.77
+Release:        77%{?dist}
 Summary:        Daemon that manages block devices to create filesystems
 
 License:        MPLv2.0
@@ -74,5 +74,5 @@ mv %{buildroot}%{_bindir}/stratisd %{buildroot}%{_libexecdir}/stratisd
 %{_unitdir}/stratisd.service
 
 %changelog
-* Fri Mar 22 2233 Stratis Team <stratis-team@redhat.com> - 1.0.9-9
-- Update to 1.0.9-9
+* Fri Mar 22 2233 Stratis Team <stratis-team@redhat.com> - 77.77.77-77
+- Update to 77.77.77-77


### PR DESCRIPTION
Advance the artificial version number of the stratisd and stratis-cli
packages to 77.77.77-77, to indicate a testing version of the
stratisd and stratis-cli packages, which should be newer than any
released version.

(Any older versions of the stratisd and stratis-cli source
 directories will remain, but will not interfere with the blackbox
test process.)

Signed-off-by: Bryan Gurney <bgurney@redhat.com>