### PR TITLE
ci: remove keyutils from dependencies_fedora

### DIFF
--- a/dependencies_fedora.sh
+++ b/dependencies_fedora.sh
@@ -22,7 +22,6 @@ dnf -y install git \
 	dbus-python \
 	dbus-python-devel \
 	device-mapper-persistent-data \
-	keyutils \
 	openssl-devel \
 	systemd-devel \
 	systemd-devel.i686 \


### PR DESCRIPTION
Closes: #92 