### PR TITLE
ci: add clevis and clevis-luks to Fedora dependencies

### DIFF
--- a/dependencies_fedora.sh
+++ b/dependencies_fedora.sh
@@ -14,6 +14,8 @@ dnf -y install git \
 	glibc-devel.x86_64 \
 	llvm \
 	llvm-devel \
+	clevis \
+	clevis-luks \
 	cryptsetup-devel \
 	dbus-devel \
 	dbus-devel.i686 \


### PR DESCRIPTION
Related: stratis-storage/project#227