### PR TITLE
ci: replace dbus-python dependency with python3-dbus

### DIFF
--- a/dependencies_fedora.sh
+++ b/dependencies_fedora.sh
@@ -23,10 +23,10 @@ dnf -y install git \
 	dbus-devel.i686 \
 	dbus-devel.x86_64 \
 	dbus-glib-devel \
-	dbus-python \
 	dbus-python-devel \
 	device-mapper-persistent-data \
 	openssl-devel \
+	python3-dbus \
 	systemd-devel \
 	systemd-devel.i686 \
 	systemd-devel.x86_64 \


### PR DESCRIPTION
Closes: #122 