### PR TITLE
mockbuild.sh: update Rawhide DIST to fc44

### DIFF
--- a/mockbuild_test/generate_sourcerpms.sh
+++ b/mockbuild_test/generate_sourcerpms.sh
@@ -29,15 +29,15 @@ case $DIST_RELEASE in
 	;;
 
 "fedora-next")
-	MOCKCONFIG="/etc/mock/fedora-43-x86_64.cfg"
+	MOCKCONFIG="/etc/mock/fedora-44-x86_64.cfg"
 	;;
 
 "fedora-latest")
-	MOCKCONFIG="/etc/mock/fedora-42-x86_64.cfg"
+	MOCKCONFIG="/etc/mock/fedora-43-x86_64.cfg"
 	;;
 
 "fedora-previous")
-	MOCKCONFIG="/etc/mock/fedora-41-x86_64.cfg"
+	MOCKCONFIG="/etc/mock/fedora-42-x86_64.cfg"
 	;;
 
 *)

--- a/mockbuild_test/mockbuild.sh
+++ b/mockbuild_test/mockbuild.sh
@@ -27,23 +27,23 @@ case $DIST_RELEASE in
 	;;
 
 "fedora-rawhide")
-	DIST="fc43"
+	DIST="fc44"
 	MOCKCONFIG="/etc/mock/fedora-rawhide-x86_64.cfg"
 	;;
 
 "fedora-next")
+	DIST="fc44"
+	MOCKCONFIG="/etc/mock/fedora-44-x86_64.cfg"
+	;;
+
+"fedora-latest")
 	DIST="fc43"
 	MOCKCONFIG="/etc/mock/fedora-43-x86_64.cfg"
 	;;
 
-"fedora-latest")
+"fedora-previous")
 	DIST="fc42"
 	MOCKCONFIG="/etc/mock/fedora-42-x86_64.cfg"
-	;;
-
-"fedora-previous")
-	DIST="fc41"
-	MOCKCONFIG="/etc/mock/fedora-41-x86_64.cfg"
 	;;
 
 *)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated Fedora build targets to current releases for testing/build pipelines: rawhide and next now track 44, latest tracks 43, and previous tracks 42.
  - Refreshed environment configurations to align with these Fedora versions, improving compatibility and keeping CI/builds current.
  - No changes to user-facing functionality; routines and control flow remain the same.
  - No changes to public APIs or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->