### PR TITLE
Increase GitHub Action checkout version to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:41  # CURRENT DEVELOPMENT ENVIRONMENT
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         run: >
           dnf install -y

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,8 @@ jobs:
     container: fedora:41  # CURRENT DEVELOPMENT ENVIRONMENT
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: >
           dnf install -y


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded CI checkout step to the latest major version to modernize our pipeline.
  * Adjusted checkout settings to avoid persisting credentials during automated runs.
  * Improves reliability, performance, and security of repository checkout in CI.
  * No changes to product functionality; routine maintenance. No user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->