### PR TITLE
Remove install of tab-completion files

### DIFF
--- a/mockbuild_test/stratis-cli.spec
+++ b/mockbuild_test/stratis-cli.spec
@@ -42,15 +42,6 @@ a2x -f manpage docs/stratis.txt
 
 %install
 %py3_install
-# Do not install tab-completion files for RHEL
-%if !0%{?rhel}
-%{__install} -Dpm0644 -t %{buildroot}%{_datadir}/bash-completion/completions \
-  shell-completion/bash/stratis
-%{__install} -Dpm0644 -t %{buildroot}%{_datadir}/zsh/site-functions \
-  shell-completion/zsh/_stratis
-%{__install} -Dpm0644 -t %{buildroot}%{_datadir}/fish/vendor_completions.d \
-  shell-completion/fish/stratis.fish
-%endif
 %{__install} -Dpm0644 -t %{buildroot}%{_mandir}/man8 docs/stratis.8
 
 %files
@@ -58,17 +49,6 @@ a2x -f manpage docs/stratis.txt
 %doc README.rst
 %{_bindir}/stratis
 %{_mandir}/man8/stratis.8*
-%if !0%{?rhel}
-%dir %{_datadir}/bash-completion
-%dir %{_datadir}/bash-completion/completions
-%{_datadir}/bash-completion/completions/stratis
-%dir %{_datadir}/zsh
-%dir %{_datadir}/zsh/site-functions
-%{_datadir}/zsh/site-functions/_stratis
-%dir %{_datadir}/fish
-%dir %{_datadir}/fish/vendor_completions.d
-%{_datadir}/fish/vendor_completions.d/stratis.fish
-%endif
 %{python3_sitelib}/stratis_cli/
 %{python3_sitelib}/stratis_cli-*.egg-info/
 


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Packaging update: Shell completion scripts (bash, zsh, fish) are no longer included or installed by the RPM package. Only the man pages are installed.
  - Users who rely on completions should configure them manually or use alternative installation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->