### PR TITLE
stratisd.spec: Change dracut order number from 90 to 50

### DIFF
--- a/mockbuild_test/stratisd.spec
+++ b/mockbuild_test/stratisd.spec
@@ -151,12 +151,12 @@ a2x -f manpage docs/stratis-dumpmetadata.txt
 
 %files dracut
 %license LICENSE
-%{dracutdir}/modules.d/90stratis-clevis/module-setup.sh
-%{dracutdir}/modules.d/90stratis-clevis/stratis-clevis-rootfs-setup
-%{dracutdir}/modules.d/90stratis/61-stratisd.rules
-%{dracutdir}/modules.d/90stratis/module-setup.sh
-%{dracutdir}/modules.d/90stratis/stratis-rootfs-setup
-%{dracutdir}/modules.d/90stratis/stratisd-min.service
+%{dracutdir}/modules.d/50stratis-clevis/module-setup.sh
+%{dracutdir}/modules.d/50stratis-clevis/stratis-clevis-rootfs-setup
+%{dracutdir}/modules.d/50stratis/61-stratisd.rules
+%{dracutdir}/modules.d/50stratis/module-setup.sh
+%{dracutdir}/modules.d/50stratis/stratis-rootfs-setup
+%{dracutdir}/modules.d/50stratis/stratisd-min.service
 %{_systemd_util_dir}/system-generators/stratis-clevis-setup-generator
 %{_systemd_util_dir}/system-generators/stratis-setup-generator
 


### PR DESCRIPTION
Related https://github.com/stratis-storage/stratisd/pull/3908

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted initramfs integration by moving Stratis and Stratis-Clevis dracut modules to an earlier load directory (modules.d/50), covering setup scripts, udev rules, and the minimal service.
  * Systemd generators for Stratis and Stratis-Clevis remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->