### PR TITLE
Make RHEL 9 and RHEL 10 cargo_test arguments consistent

### DIFF
--- a/mockbuild_test/stratisd.spec
+++ b/mockbuild_test/stratisd.spec
@@ -109,7 +109,7 @@ a2x -f manpage docs/stratis-dumpmetadata.txt
 
 %if %{with check}
 %check
-%if 0%{?rhel} && 0%{?rhel} < 10
+%if 0%{?rhel} && 0%{?rhel} < 9
 %cargo_test --no-run
 %else
 %cargo_test -- --no-run


### PR DESCRIPTION
Closes https://github.com/stratis-storage/ci/issues/559